### PR TITLE
chore: bump node workflow version to 20.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.18"
+          node-version: "20.12"
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -94,7 +94,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.18"
+          node-version: "20.12"
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -130,7 +130,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.18"
+          node-version: "20.12"
       - name: Install Build and publish assets dependencies
         run: |-
           pip install cfn-flip && cfn-flip --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.18"
+          node-version: "20.12"
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.18"
+          node-version: "20.12"
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.18"
+          node-version: "20.12"
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -151,7 +151,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.18"
+          node-version: "20.12"
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.18"
+          node-version: "20.12"
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -40,7 +40,8 @@ const project = new awscdk.AwsCdkConstructLibrary({
   // however we cannot build anymore
   // https://github.com/MV-Consulting/awscdk-rootmail/actions/runs/9606321210/job/26495659910#step:5:697
   // so we need to update to 18.18
-  workflowNodeVersion: '18.18',
+  // now bump to 20.12
+  workflowNodeVersion: '20.12',
 
   bundledDeps: [
     '@aws-sdk/client-cloudwatch-logs',
@@ -167,7 +168,7 @@ if (buildWorkflow) {
           name: 'Setup Node.js',
           uses: 'actions/setup-node@v4',
           with: {
-            'node-version': '18.18',
+            'node-version': '20.12',
           },
         },
         {
@@ -235,7 +236,7 @@ if (releaseWorkflow) {
           name: 'Setup Node.js',
           uses: 'actions/setup-node@v4',
           with: {
-            'node-version': '18.18',
+            'node-version': '20.12',
           },
         },
         // As in the other release jobs


### PR DESCRIPTION
only bumps